### PR TITLE
Nat gateway missing

### DIFF
--- a/Modules/Networking/NATGAteway.ps1
+++ b/Modules/Networking/NATGAteway.ps1
@@ -40,6 +40,18 @@ If ($Task -eq 'Processing') {
                             {
                                 foreach ($Tag in $Tags) 
                                     {  
+                                        $t_pip_addresses = ''
+                                        $t_pip_prefixes = ''
+
+                                        if (!$data.publicipaddresses) {
+                                            $t_pip_addresses = [string]$data.publicipaddresses.id.split("/")[8]
+                                        }
+
+                                        
+                                        if (!$data.publicipprefixes) {
+                                            $t_pip_prefixes = [string]$data.publicipprefixes.id.split("/")[8]
+                                        }
+
                                         $obj = @{
                                             'ID'                    = $1.id;
                                             'Subscription'          = $sub1.Name;
@@ -48,8 +60,8 @@ If ($Task -eq 'Processing') {
                                             'Location'              = $1.LOCATION;
                                             'SKU'                   = $1.sku.name;
                                             'Idle Timeout (Min)'    = $data.idleTimeoutInMinutes;
-                                            'Public IP'             = [string]$data.publicipaddresses.id.split("/")[8];
-                                            'Public Prefixes'       = [string]$data.publicipprefixes.id.split("/")[8];
+                                            'Public IP'             = $t_pip_addresses;
+                                            'Public Prefixes'       = $t_pip_prefixes;
                                             'VNET'                  = [string]$2.id.split("/")[8];
                                             'Subnet'                = [string]$2.id.split("/")[10];
                                             'Resource U'            = $ResUCount;

--- a/Modules/Networking/NATGAteway.ps1
+++ b/Modules/Networking/NATGAteway.ps1
@@ -43,12 +43,12 @@ If ($Task -eq 'Processing') {
                                         $t_pip_addresses = ''
                                         $t_pip_prefixes = ''
 
-                                        if (!$data.publicipaddresses) {
+                                        if (!!$data.publicipaddresses) {
                                             $t_pip_addresses = [string]$data.publicipaddresses.id.split("/")[8]
                                         }
 
                                         
-                                        if (!$data.publicipprefixes) {
+                                        if (!!$data.publicipprefixes) {
                                             $t_pip_prefixes = [string]$data.publicipprefixes.id.split("/")[8]
                                         }
 


### PR DESCRIPTION
NAT Gateways without public ip prefix are not loaded. My suggestion is to validate the property before trying to execute the split method. If the value is null, the method is not executed and the object is not loaded.