### PR TITLE
Fixing the filtering and loading of subscription names

### DIFF
--- a/Extras/Subscriptions.ps1
+++ b/Extras/Subscriptions.ps1
@@ -29,10 +29,10 @@ If ($Task -eq 'Processing')
 
             foreach ($ResourcesSUB in $ResTable3) {
                 $ResourceDetails = $ResourcesSUB.name -split ","
-                $SubName = $Subscriptions | Where-Object { $_.Subscription.Id -eq ($ResourceDetails[3] -replace (" ", "")) }
+                $SubName = $Subscriptions | Where-Object { $_.Id -eq ($ResourceDetails[3] -replace (" ", "")) }
 
                 $obj = @{
-                    'Subscription'   = $SubName.Subscription.Name;
+                    'Subscription'   = $SubName.Name;
                     'Resource Group' = $ResourceDetails[2];
                     'Location'       = $ResourceDetails[1];
                     'Resource Type'  = $ResourceDetails[0];


### PR DESCRIPTION
The name of the subscriptions is not being loaded, also impacting the resources per subscription graph. Here's a correction suggestion in the subscriptions module to correctly filter the subscription and load its name.

