### PR TITLE
Fix for SQL Server Private Endpoints listing

### DIFF
--- a/Modules/Data/SQLSERVER.ps1
+++ b/Modules/Data/SQLSERVER.ps1
@@ -35,8 +35,12 @@ if ($Task -eq 'Processing') {
                 $ResUCount = 1
                 $sub1 = $SUB | Where-Object { $_.id -eq $1.subscriptionId }
                 $data = $1.PROPERTIES
-                if([string]::IsNullOrEmpty($data.privateEndpointConnections)){$PVTENDP = $false}else{$PVTENDP = $data.privateEndpointConnections.Id.split("/")[8]}
-                $Tags = if(![string]::IsNullOrEmpty($1.tags.psobject.properties)){$1.tags.psobject.properties}else{'0'}
+               
+                $Tags = if(!!($1.tags.psobject.properties)){$1.tags.psobject.properties}else{'0'}
+
+                $pvteps = if(!($data.privateEndpointConnections)) {[pscustomobject]@{id = 'NONE'}} else {$data.privateEndpointConnections | Select-Object @{Name="id";Expression={$_.id.split("/")[10]}}}
+
+                foreach ($pvtep in $pvteps) {
                     foreach ($Tag in $Tags) {
                         $obj = @{
                             'ID'                    = $1.id;
@@ -46,7 +50,7 @@ if ($Task -eq 'Processing') {
                             'Location'              = $1.LOCATION;
                             'Kind'                  = $1.kind;
                             'Admin Login'           = $data.administratorLogin;
-                            'Private Endpoint'      = $PVTENDP;
+                            'Private Endpoint'      = $pvtep.id;
                             'FQDN'                  = $data.fullyQualifiedDomainName;
                             'Public Network Access' = $data.publicNetworkAccess;
                             'State'                 = $data.state;
@@ -58,7 +62,8 @@ if ($Task -eq 'Processing') {
                         }
                         $tmp += $obj
                         if ($ResUCount -eq 1) { $ResUCount = 0 } 
-                    }               
+                    }     
+                }          
             }
             $tmp
         }


### PR DESCRIPTION
SQL servers with only one private endpoint are not being listed. This is due to the erratic behavior of the [String]::IsNullOrEmpty method being used with array of objects. When the object (privateEndpointConnections) has more than one element it returns $false, but when the object has only one element it returns $true. That way, ignoring unique private endpoints. I'm proposing to fix the object test and add a new loop for listing multiple private endpoints on the same SQL Server.

I understand that **all modules** need review. The use of the **[string]::IsNullOrEmpty** method can generate unwanted effects, as the method expects a String and not a collection or array of objects. When passing an array of objects, it is converted to a string. This test will only work in scenarios where there is no value or in scenarios with more than one value. For example, consider two arrays pvt1 and pvt2 containing private Endpoint Connections:

pvt1
<img width="874" alt="image" src="https://user-images.githubusercontent.com/8357024/167245368-52f74dfc-bfa0-4e85-8119-94cdafd14aba.png">


pvt2
<img width="872" alt="image" src="https://user-images.githubusercontent.com/8357024/167245350-ef79b5f8-02ff-43e3-b7cb-8b7750b817d5.png">

Checking the values with [String]::IsNullOrEmpty will return:

[String]::IsNullOrEmpty($pvt1) => $false
[String]::IsNullOrEmpty($pvt2) => $true

**Both have data**, but for one of them the function returned $true, ie null or empty.

This inappropriate use of the method can cause inaccuracy when reporting some resources or properties.





