### PR TITLE
Refactor conditional formatting for columns "Kubernetes Version" and "Node Pool Version" in AKS report

### DIFF
--- a/Modules/Private/3.ReportingFunctions/Start-ARIExcelExtraData.ps1
+++ b/Modules/Private/3.ReportingFunctions/Start-ARIExcelExtraData.ps1
@@ -60,13 +60,13 @@ function Start-ARIExcelExtraData {
             {
                 $sheet = $excel.Workbook.Worksheets[$SheetName]
 
-                #AKS Version
-                Add-ConditionalFormatting -WorkSheet $sheet -RuleType Between -ConditionValue "1.29.0" -ConditionValue2 "1.31.99" -Address H:H -BackgroundColor "Yellow"
-                Add-ConditionalFormatting -WorkSheet $sheet -RuleType Between -ConditionValue "1.20.0" -ConditionValue2 "1.28.99" -Address H:H -BackgroundColor 'LightPink' -ForegroundColor 'DarkRed'
+                #AKS Version (yellow for version 1.29.0 - 1.31.99, light pink for 1.20.0 - 1.28.99)
+                Add-ConditionalFormatting -Worksheet $sheet -RuleType Expression -ConditionValue 'AND(TEXT(LEFT($H1,FIND(".",$H1)-1),"000")&"."&TEXT(MID($H1,FIND(".",$H1)+1,FIND("~",SUBSTITUTE($H1,".","~",2))-FIND(".",$H1)-1),"000")&"."&TEXT(RIGHT($H1,LEN($H1)-FIND("~",SUBSTITUTE($H1,".","~",2))),"000")>="001.029.000",TEXT(LEFT($H1,FIND(".",$H1)-1),"000")&"."&TEXT(MID($H1,FIND(".",$H1)+1,FIND("~",SUBSTITUTE($H1,".","~",2))-FIND(".",$H1)-1),"000")&"."&TEXT(RIGHT($H1,LEN($H1)-FIND("~",SUBSTITUTE($H1,".","~",2))),"000")<="001.031.999")' -Address H:H -BackgroundColor "Yellow"
+                Add-ConditionalFormatting -Worksheet $sheet -RuleType Expression -ConditionValue 'AND(TEXT(LEFT($H1,FIND(".",$H1)-1),"000")&"."&TEXT(MID($H1,FIND(".",$H1)+1,FIND("~",SUBSTITUTE($H1,".","~",2))-FIND(".",$H1)-1),"000")&"."&TEXT(RIGHT($H1,LEN($H1)-FIND("~",SUBSTITUTE($H1,".","~",2))),"000")>="001.020.000",TEXT(LEFT($H1,FIND(".",$H1)-1),"000")&"."&TEXT(MID($H1,FIND(".",$H1)+1,FIND("~",SUBSTITUTE($H1,".","~",2))-FIND(".",$H1)-1),"000")&"."&TEXT(RIGHT($H1,LEN($H1)-FIND("~",SUBSTITUTE($H1,".","~",2))),"000")<="001.028.999")' -Address H:H -BackgroundColor 'LightPink' -ForegroundColor 'DarkRed'
 
-                #NodePool Version
-                Add-ConditionalFormatting -WorkSheet $sheet -RuleType Between -ConditionValue "1.29.0" -ConditionValue2 "1.31.99" -Address AE:AE -BackgroundColor "Yellow"
-                Add-ConditionalFormatting -WorkSheet $sheet -RuleType Between -ConditionValue "1.20.0" -ConditionValue2 "1.28.99" -Address AE:AE -BackgroundColor 'LightPink' -ForegroundColor 'DarkRed'
+                #NodePool Version (yellow for version 1.29.0 - 1.31.99, light pink for 1.20.0 - 1.28.99)
+                Add-ConditionalFormatting -Worksheet $sheet -RuleType Expression -ConditionValue 'AND(TEXT(LEFT($AE1,FIND(".",$AE1)-1),"000")&"."&TEXT(MID($AE1,FIND(".",$AE1)+1,FIND("~",SUBSTITUTE($AE1,".","~",2))-FIND(".",$AE1)-1),"000")&"."&TEXT(RIGHT($AE1,LEN($AE1)-FIND("~",SUBSTITUTE($AE1,".","~",2))),"000")>="001.029.000",TEXT(LEFT($AE1,FIND(".",$AE1)-1),"000")&"."&TEXT(MID($AE1,FIND(".",$AE1)+1,FIND("~",SUBSTITUTE($AE1,".","~",2))-FIND(".",$AE1)-1),"000")&"."&TEXT(RIGHT($AE1,LEN($AE1)-FIND("~",SUBSTITUTE($AE1,".","~",2))),"000")<="001.031.999")' -Address AE:AE -BackgroundColor "Yellow"
+                Add-ConditionalFormatting -Worksheet $sheet -RuleType Expression -ConditionValue 'AND(TEXT(LEFT($AE1,FIND(".",$AE1)-1),"000")&"."&TEXT(MID($AE1,FIND(".",$AE1)+1,FIND("~",SUBSTITUTE($AE1,".","~",2))-FIND(".",$AE1)-1),"000")&"."&TEXT(RIGHT($AE1,LEN($AE1)-FIND("~",SUBSTITUTE($AE1,".","~",2))),"000")>="001.020.000",TEXT(LEFT($AE1,FIND(".",$AE1)-1),"000")&"."&TEXT(MID($AE1,FIND(".",$AE1)+1,FIND("~",SUBSTITUTE($AE1,".","~",2))-FIND(".",$AE1)-1),"000")&"."&TEXT(RIGHT($AE1,LEN($AE1)-FIND("~",SUBSTITUTE($AE1,".","~",2))),"000")<="001.028.999")' -Address AE:AE -BackgroundColor 'LightPink' -ForegroundColor 'DarkRed'
 
                 #Remaining Quota
                 Add-ConditionalFormatting -WorkSheet $sheet -RuleType Between -ConditionValue 50 -ConditionValue2 100 -Address AO:AO -BackgroundColor "Yellow"


### PR DESCRIPTION
The current conditional formatting for AKS version and AKS nodepool throws errors when opening the resulting Excel.

**Error message**

<img width="545" height="314" alt="image" src="https://github.com/user-attachments/assets/2733f61e-ee5a-4106-b875-114f006aa7a6" />

**Reair message**

<img width="699" height="380" alt="image" src="https://github.com/user-attachments/assets/3e09113c-28a8-41a2-bb0e-0871fe5e773a" />

**Repair log**

<img width="1350" height="293" alt="image" src="https://github.com/user-attachments/assets/9bcfb48c-8a50-4e8a-8870-f5130cccc838" />

I changed the rule type from **Between** to **Expression** and added the required conditional formatting formula.

Changes to the version numbers must be done in the format "000.000.000" directly in the formula.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/ARI/pull/351)
 
Additionally I updated the conditional formatting values to reflect the current AKS lifecycle table.
 
**Before (red formatting for all versions before 1.29 - not on table anymore):**

<img width="1278" height="397" alt="image" src="https://github.com/user-attachments/assets/c412cd51-6b11-49d3-b4cc-367cc8130ef9" />

 
**After:**

<img width="1278" height="397" alt="image" src="https://github.com/user-attachments/assets/bb9b0049-b516-458c-8bec-040c51b4b480" />
