### PR TITLE
Updates to collection properties and TagKey filter fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ $RECYCLE.BIN/
 
 # Dependency directories
 vendor/
+additions.md

--- a/Modules/Private/1.ExtractionFunctions/Start-ARIGraphExtraction.ps1
+++ b/Modules/Private/1.ExtractionFunctions/Start-ARIGraphExtraction.ps1
@@ -70,9 +70,20 @@ Function Start-ARIGraphExtraction {
                 {
                     $RGQueryExtension = "| where resourceGroup in~ ('$([String]::Join("','",$ResourceGroup))')"
                 }
-            elseif(![string]::IsNullOrEmpty($TagKey) -and ![string]::IsNullOrEmpty($TagValue))
+            elseif(![string]::IsNullOrEmpty($TagKey) -or ![string]::IsNullOrEmpty($TagValue))
                 {
-                    $TagQueryExtension = "| where isnotempty(tags) | mvexpand tags | extend tagKey = tostring(bag_keys(tags)[0]) | extend tagValue = tostring(tags[tagKey]) | where tagKey =~ '$TagKey' and tagValue =~ '$TagValue'"
+
+                    $TagQueryExtension = "| where isnotempty(tags) | mvexpand tags | extend tagKey = tostring(bag_keys(tags)[0]) | extend tagValue = tostring(tags[tagKey]) "
+
+                    if (![string]::IsNullOrEmpty($TagKey)){ 
+                        $TagQueryExtension = $TagQueryExtension + "| where tagKey =~ '$TagKey'"
+                    }
+
+                    if (![string]::IsNullOrEmpty($TagValue)){ 
+                        $TagQueryExtension = $TagQueryExtension + " and tagValue =~ '$TagValue'"
+                    }
+
+                    #$TagQueryExtension = "| where isnotempty(tags) | mvexpand tags | extend tagKey = tostring(bag_keys(tags)[0]) | extend tagValue = tostring(tags[tagKey]) | where tagKey =~ '$TagKey' and tagValue =~ '$TagValue'"
                 }
             elseif (![string]::IsNullOrEmpty($ManagementGroup))
                 {

--- a/Modules/Public/InventoryModules/Database/CosmosDB.ps1
+++ b/Modules/Public/InventoryModules/Database/CosmosDB.ps1
@@ -117,12 +117,11 @@ Else {
         $Style = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat 0
 
         $condtxt = @()
-        $condtxt += New-ConditionalText FALSE -Range L:L
-        $condtxt += New-ConditionalText Enabled -Range O:O
-        $condtxt += New-ConditionalText Disabled -Range K:K
-        $condtxt += New-ConditionalText Local -Range I:I
-        #Retirement
-        $condtxt += New-ConditionalText -Range E2:E100 -ConditionalType ContainsText
+        $condtxt += New-ConditionalText Local -Range I:I                                #Backup Storage Redundancy
+        $condtxt += New-ConditionalText Disabled -Range K:K                             #Replicate Data Globally
+        $condtxt += New-ConditionalText FALSE -Range L:L                                #VNET Filtering
+        $condtxt += New-ConditionalText Enabled -Range O:O                              #Public Access
+        $condtxt += New-ConditionalText -Range E2:E100 -ConditionalType ContainsText    #Retiring Feature
 
         $Exc = New-Object System.Collections.Generic.List[System.Object]
         $Exc.Add('Subscription')

--- a/Modules/Public/InventoryModules/Database/CosmosDB.ps1
+++ b/Modules/Public/InventoryModules/Database/CosmosDB.ps1
@@ -86,6 +86,7 @@ If ($Task -eq 'Processing') {
                             'VNET Filtering'            = $data.isVirtualNetworkFilterEnabled;
                             'Virtual Networks'          = [string]$VNETs;
                             'Free Tier Discount'        = $FreeTier;
+                            'Capabilities'              = ($data.capabilities).Name;
                             'Public Access'             = $data.publicNetworkAccess;
                             'Default Consistency'       = $data.consistencyPolicy.defaultConsistencyLevel;
                             'Private Endpoint'          = $PVTENDP;
@@ -137,6 +138,7 @@ Else {
         $Exc.Add('VNET Filtering')
         $Exc.Add('Virtual Networks')
         $Exc.Add('Free Tier Discount')
+        $Exc.Add('Capabilities')
         $Exc.Add('Public Access')
         $Exc.Add('Default Consistency')
         $Exc.Add('Private Endpoint')

--- a/Modules/Public/InventoryModules/Database/CosmosDB.ps1
+++ b/Modules/Public/InventoryModules/Database/CosmosDB.ps1
@@ -85,6 +85,7 @@ If ($Task -eq 'Processing') {
                             'Replicate Data Globally'   = $GeoReplicate;
                             'VNET Filtering'            = $data.isVirtualNetworkFilterEnabled;
                             'Virtual Networks'          = [string]$VNETs;
+                            'Capacity'                  = $data.capapcity.totalthroughputlimit;
                             'Free Tier Discount'        = $FreeTier;
                             'Public Access'             = $data.publicNetworkAccess;
                             'Default Consistency'       = $data.consistencyPolicy.defaultConsistencyLevel;
@@ -136,6 +137,7 @@ Else {
         $Exc.Add('Replicate Data Globally')
         $Exc.Add('VNET Filtering')
         $Exc.Add('Virtual Networks')
+        $Exc.Add('Capacity')
         $Exc.Add('Free Tier Discount')
         $Exc.Add('Public Access')
         $Exc.Add('Default Consistency')

--- a/Modules/Public/InventoryModules/Database/SQLSERVER.ps1
+++ b/Modules/Public/InventoryModules/Database/SQLSERVER.ps1
@@ -77,6 +77,7 @@ if ($Task -eq 'Processing') {
                             'Private Endpoint'      = $pvtep.id;
                             'FQDN'                  = $data.fullyQualifiedDomainName;
                             'Public Network Access' = $data.publicNetworkAccess;
+                            'minimalTlsVersion'     = $data.minimalTlsVersion;
                             'State'                 = $data.state;
                             'Version'               = $data.version;
                             'Resource U'            = $ResUCount;
@@ -116,6 +117,7 @@ else {
         $Exc.Add('Private Endpoint')
         $Exc.Add('FQDN')
         $Exc.Add('Public Network Access')
+        $Exc.Add('minimalTlsVersion')
         $Exc.Add('State')
         $Exc.Add('Version')
         $Exc.Add('Zone Redundant')

--- a/Modules/Public/InventoryModules/Database/SQLSERVER.ps1
+++ b/Modules/Public/InventoryModules/Database/SQLSERVER.ps1
@@ -100,10 +100,9 @@ else {
         $Style = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat 0
 
         $condtxt = @()
-        $condtxt += New-ConditionalText FALSE -Range I:I
-        $condtxt += New-ConditionalText Enabled -Range K:K
-        #Retirement
-        $condtxt += New-ConditionalText -Range E2:E100 -ConditionalType ContainsText
+        $condtxt += New-ConditionalText FALSE -Range I:I                                #Private Endpoint  
+        $condtxt += New-ConditionalText Enabled -Range K:K                              #Public Network Access
+        $condtxt += New-ConditionalText -Range E2:E100 -ConditionalType ContainsText    #Retiring Feature
 
         $Exc = New-Object System.Collections.Generic.List[System.Object]
         $Exc.Add('Subscription')

--- a/Modules/Public/InventoryModules/Integration/APIM.ps1
+++ b/Modules/Public/InventoryModules/Integration/APIM.ps1
@@ -115,8 +115,7 @@ Else
         $Style = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat '0'
 
         $condtxt = @()
-        #Retirement
-        $condtxt += New-ConditionalText -Range F2:F100 -ConditionalType ContainsText
+        $condtxt += New-ConditionalText -Range G2:G100 -ConditionalType ContainsText    #Retiring Feature
 
         $Exc = New-Object System.Collections.Generic.List[System.Object]
         $Exc.Add('Subscription')

--- a/Modules/Public/InventoryModules/Integration/APIM.ps1
+++ b/Modules/Public/InventoryModules/Integration/APIM.ps1
@@ -75,6 +75,7 @@ If ($Task -eq 'Processing')
                             'Name'                 = $1.NAME;
                             'Location'             = $1.LOCATION;
                             'SKU'                  = $1.sku.name;
+                            'Sku Capacity'         = $1.sku.capacity;
                             'Retiring Feature'     = $RetiringFeature;
                             'Retiring Date'        = $RetiringDate;
                             'Gateway URL'          = $data.gatewayUrl;
@@ -123,6 +124,7 @@ Else
         $Exc.Add('Name')
         $Exc.Add('Location')
         $Exc.Add('SKU')
+        $Exc.Add('Sku Capacity')
         $Exc.Add('Retiring Feature')
         $Exc.Add('Retiring Date')
         $Exc.Add('Gateway URL')

--- a/Modules/Public/InventoryModules/Storage/StorageAccounts.ps1
+++ b/Modules/Public/InventoryModules/Storage/StorageAccounts.ps1
@@ -79,6 +79,8 @@ If ($Task -eq 'Processing') {
                 $CrossTNT = if($data.allowCrossTenantReplication -eq $true){$true}else{$false}
                 $InfrastructureEncryption = if($data.encryption.requireInfrastructureEncryption -eq "True"){$true}else{$false}
 
+                
+
                 if ($data.azureFilesIdentityBasedAuthentication.directoryServiceOptions -eq 'None')
                     {
                         $EntraID = $false
@@ -128,6 +130,10 @@ If ($Task -eq 'Processing') {
                 $FinalACLIPs = [string]$FinalACLIPs
                 $FinalACLIPs = if ($FinalACLIPs -like '* ,*') { $FinalACLIPs -replace ".$" }else { $FinalACLIPs }
 
+                $sac = Get-AzStorageAccount -ResourceGroupName $1.RESOURCEGROUP -Name $1.NAME
+                $ctx=$sac.Context
+                $blobProperties = Get-AzStorageServiceProperty -ServiceType Blob -Context $ctx
+
                 foreach ($2 in $VNETRules)
                     {
                         $VNET = if(![string]::IsNullOrEmpty($2.id)){$2.id.split('/')[8]}else{''}
@@ -151,6 +157,7 @@ If ($Task -eq 'Processing') {
                                 'Microsoft Entra Authorization'         = $EntraID;
                                 'Allow Storage Account Key Access'      = $KeyAccess;
                                 'SFTP Enabled'                          = $SFTPEnabled;
+                                'Blob Soft Delete Days'                 = if ($blobProperties.DeleteRetentionPolicy.Enabled) { $blobProperties.DeleteRetentionPolicy.RetentionDays } else { 'N/A' };
                                 'Hierarchical Namespace'                = $HNSEnabled;
                                 'NFSv3 Enabled'                         = $NFSv3;
                                 'Large File Shares'                     = $LargeFileShare;
@@ -227,6 +234,7 @@ Else {
         $Exc.Add('Microsoft Entra Authorization')
         $Exc.Add('Allow Storage Account Key Access')
         $Exc.Add('SFTP Enabled')
+        $Exc.Add('Blob Soft Delete Days')
         $Exc.Add('Hierarchical Namespace')
         $Exc.Add('NFSv3 Enabled')
         $Exc.Add('Large File Shares')

--- a/Modules/Public/InventoryModules/Storage/StorageAccounts.ps1
+++ b/Modules/Public/InventoryModules/Storage/StorageAccounts.ps1
@@ -164,6 +164,7 @@ If ($Task -eq 'Processing') {
                                 'Access Tier'                           = $data.accessTier;
                                 'Allow Cross Tenant Replication'        = $CrossTNT;
                                 'Infrastructure Encryption Enabled'     = $InfrastructureEncryption;
+                                'minimumTlsVersion'                     = $data.minimumTlsVersion;
                                 'Public Network Access'                 = $PubNetAccess;
                                 'Private Endpoints'                     = $FinalPVTEndpoint;
                                 'Direct Access Resources'               = $FinalDirectResources;
@@ -241,6 +242,7 @@ Else {
         $Exc.Add('Access Tier')
         $Exc.Add('Allow Cross Tenant Replication')
         $Exc.Add('Infrastructure Encryption Enabled')
+        $Exc.Add('minimumTlsVersion')
         $Exc.Add('Public Network Access')
         $Exc.Add('Private Endpoints')
         $Exc.Add('Direct Access Resources')

--- a/Modules/Public/InventoryModules/Storage/StorageAccounts.ps1
+++ b/Modules/Public/InventoryModules/Storage/StorageAccounts.ps1
@@ -164,7 +164,6 @@ If ($Task -eq 'Processing') {
                                 'Access Tier'                           = $data.accessTier;
                                 'Allow Cross Tenant Replication'        = $CrossTNT;
                                 'Infrastructure Encryption Enabled'     = $InfrastructureEncryption;
-                                'minimumTlsVersion'                     = $data.minimumTlsVersion;
                                 'Public Network Access'                 = $PubNetAccess;
                                 'Private Endpoints'                     = $FinalPVTEndpoint;
                                 'Direct Access Resources'               = $FinalDirectResources;
@@ -207,16 +206,16 @@ Else {
         )
 
         $condtxt = @()
-        $condtxt += New-ConditionalText false -Range K:K
-        $condtxt += New-ConditionalText true -Range L:L
-        $condtxt += New-ConditionalText 1.0 -Range M:M
-        $condtxt += New-ConditionalText 1.1 -Range M:M
-        $condtxt += New-ConditionalText all -Range W:W
-        $condtxt += New-ConditionalText . -Range AB:AB -ConditionalType ContainsText
-        $condtxt += New-ConditionalText unavailable -Range AE:AE
-        $condtxt += New-ConditionalText unavailable -Range AG:AG
-        #Retirement
-        $condtxt += New-ConditionalText -Range I2:I100 -ConditionalType ContainsText
+        $condtxt += New-ConditionalText false -Range K:K                                #Secure Transfer Required
+        $condtxt += New-ConditionalText true -Range L:L                                 #Allow Blob Anonymous Access
+        $condtxt += New-ConditionalText 1.0 -Range M:M                                  #Minimum TLS Version
+        $condtxt += New-ConditionalText 1.1 -Range M:M                                  #Minimum TLS Version
+        $condtxt += New-ConditionalText true -Range O:O                                 #Allow Storage Account Key Access
+        $condtxt += New-ConditionalText all -Range X:X                                  #Public Network Access  
+        $condtxt += New-ConditionalText . -Range AD:AD -ConditionalType ContainsText    #Firewall Exceptions
+        $condtxt += New-ConditionalText unavailable -Range AF:AF                        #Status Of Primary Location
+        $condtxt += New-ConditionalText unavailable -Range AH:AH                        #Status Of Secondary Location
+        $condtxt += New-ConditionalText -Range I2:I100 -ConditionalType ContainsText    #Retiring Feature
 
         $Exc = New-Object System.Collections.Generic.List[System.Object]
         $Exc.Add('Subscription')
@@ -242,7 +241,6 @@ Else {
         $Exc.Add('Access Tier')
         $Exc.Add('Allow Cross Tenant Replication')
         $Exc.Add('Infrastructure Encryption Enabled')
-        $Exc.Add('minimumTlsVersion')
         $Exc.Add('Public Network Access')
         $Exc.Add('Private Endpoints')
         $Exc.Add('Direct Access Resources')

--- a/Modules/Public/InventoryModules/Web/APPServices.ps1
+++ b/Modules/Public/InventoryModules/Web/APPServices.ps1
@@ -133,14 +133,13 @@ Else
         $TableName = ('AppSvcsTable_'+($SmaResources.'Resource U').count)
         $Style = New-ExcelStyle -HorizontalAlignment Center -AutoSize -NumberFormat '0'
 
-        $condtxt = @()        
-        $condtxt += New-ConditionalText FALSE -Range Q:Q
-        $condtxt += New-ConditionalText FALSE -Range R:R
-        $condtxt += New-ConditionalText FALSE -Range M:M
-        $condtxt += New-ConditionalText FALSE -Range U:U
-        $condtxt += New-ConditionalText - -Range L:L -ConditionalType ContainsText
-        #Retirement
-        $condtxt += New-ConditionalText -Range E2:E100 -ConditionalType ContainsText
+        $condtxt = @()
+        $condtxt += New-ConditionalText FALSE -Range N:N                                #Client Cert Enabled
+        $condtxt += New-ConditionalText FALSE -Range R:R                                #HTTPS Only
+        $condtxt += New-ConditionalText FALSE -Range S:S                                #FTPS Only
+        $condtxt += New-ConditionalText FALSE -Range V:V                                #Managed Identity
+        $condtxt += New-ConditionalText - -Range M:M -ConditionalType ContainsText      #State
+        $condtxt += New-ConditionalText -Range E2:E100 -ConditionalType ContainsText    #Retiring Feature
 
         $Exc = New-Object System.Collections.Generic.List[System.Object]
         $Exc.Add('Subscription')

--- a/Modules/Public/InventoryModules/Web/APPServices.ps1
+++ b/Modules/Public/InventoryModules/Web/APPServices.ps1
@@ -84,6 +84,9 @@ If ($Task -eq 'Processing')
                                 'Retiring Date'                 = $RetiringDate;
                                 'App Type'                      = $1.KIND;
                                 'Location'                      = $1.LOCATION;
+                                'zoneRedundant'                 = $data.zoneRedundant;
+                                'maximumNumberOfZones'          = $data.maximumNumberOfZones;
+                                'currentNumberOfZonesUtilized'  = $data.currentNumberOfZonesUtilized;
                                 'Enabled'                       = $data.enabled;
                                 'State'                         = $data.state;
                                 'Client Cert Enabled'           = $data.clientCertEnabled;
@@ -148,6 +151,9 @@ Else
         $Exc.Add('Retiring Date')
         $Exc.Add('App Type')
         $Exc.Add('Location')
+        $Exc.Add('zoneRedundant')
+        $Exc.Add('maximumNumberOfZones')
+        $Exc.Add('currentNumberOfZonesUtilized')
         $Exc.Add('Enabled')
         $Exc.Add('State')
         $Exc.Add('Client Cert Enabled')


### PR DESCRIPTION
Added more properties to be collected.
- Added Storage account soft delete information
- Added CosmosDB serverless information
- Added CosmosDB provisioned RUs
- Added APIM Sku capacity/Size
- Added App Service Plan Zone Redundancy and scale
- Added Storage Account minimumTlsVersion
- Added Azure SQL Server minimalTlsVersion

Also fixed TagKey filter. Do not use -includetags when filtering on -tagkey.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/ARI/pull/354)